### PR TITLE
feat: add poc for error boundary with error recovery

### DIFF
--- a/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundary.spec.js
+++ b/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundary.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import ErrorBoundaryPoc from './ErrorBoundaryPoc';
+
+const ErrorComponent = () => {
+  throw new Error('test');
+};
+
+test('render ErrorBoundaryPoc with Message', async () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const { findByText } = render(
+    <ErrorBoundaryPoc>
+      <ErrorComponent />
+    </ErrorBoundaryPoc>
+  );
+  const testStatus = await findByText(/Oops, something went wrong/i);
+  expect(testStatus).toBeInTheDocument();
+  expect(consoleSpy).toHaveBeenCalled();
+});

--- a/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundary.stories.js
+++ b/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundary.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Button } from 'carbon-components-react';
+import ErrorDragon from '../ErrorDragon';
+import ErrorBoundaryPoc from './index';
+
+const TestComponent = () => {
+  throw new Error("test");
+}
+
+storiesOf('ErrorBoundaryPoc', module)
+  .add('default', () => {
+    const [ error, setError ] = React.useState(false);
+
+    React.useEffect(() => {
+      if(error) {
+        setError(false);
+      }
+      else {
+        setTimeout(() => {
+          setError(true);
+        }, 5000);
+      }
+    }, [error]);
+
+    return (
+      <div style={{ height: '100vh', width: '40rem' }}>
+        <ErrorBoundaryPoc>
+          <div>Hey! An error will appear soon!</div>
+          {error && <TestComponent />}
+        </ErrorBoundaryPoc>
+      </div>
+    );
+  });

--- a/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundaryPoc.js
+++ b/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/ErrorBoundaryPoc.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import cx from "classnames";
+import { settings } from 'carbon-components';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Button } from 'carbon-components-react';
+import ErrorMessage from '../ErrorMessage';
+
+const { prefix } = settings;
+
+/**
+ * todo: convert this to hooks in the future.
+ * As of now getDerivedStateFromError not available via hooks
+ */
+
+function ErrorBoundaryPoc(props) {
+  const { children, className, style, errorProps, errorComponent, resetButtonText, resetButtonProps } = props;
+  const containerClassName = cx(`${prefix}--bmrg-error-boundary-poc`, className);
+  const buttonClassName = cx(`${prefix}--bmrg-error-boundary-poc-restore`, resetButtonProps?.className);
+
+  resetButtonProps["className"] = buttonClassName;
+
+  const [ error, setError ] = useState(false);
+
+  const errorHandler = (newError, info) => {
+    setError(newError);
+    console.log(error, info); //eslint-disable-line
+  }
+
+  const ErrorFallback = ({error, resetErrorBoundary}) => {
+    return (
+      <div className={containerClassName} role="alert" style={style} {...props}>
+        <ErrorComponent {...errorProps} />
+        <Button onClick={resetErrorBoundary} {...resetButtonProps}>
+          {resetButtonText}
+        </Button>
+      </div>
+    )
+  }
+
+  const ErrorComponent = errorComponent;
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback} onReset={() => setError(false)} onError={errorHandler}>
+      { children }
+    </ErrorBoundary>
+  );
+}
+
+ErrorBoundaryPoc.defaultProps = {
+  errorComponent: ErrorMessage,
+  resetButtonText: "Restore page",
+  resetButtonProps: {},
+};
+
+ErrorBoundaryPoc.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  style: PropTypes.string,
+  errorProps: PropTypes.object,
+  errorComponent: PropTypes.func,
+  resetButtonText: PropTypes.string,
+  resetButtonProps: PropTypes.object,
+};
+
+export default ErrorBoundaryPoc;

--- a/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/_errorBoundaryPoc.scss
+++ b/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/_errorBoundaryPoc.scss
@@ -1,0 +1,19 @@
+@include exports('addons-bmrg-errorBoundaryPoc') {
+  .#{$prefix}--bmrg-error-boundary-poc {
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+  .#{$prefix}--bmrg-error-boundary-poc-restore {
+    
+    margin-top: 2rem;
+  }
+}

--- a/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/index.js
+++ b/packages/carbon-addons-boomerang-react/src/components/ErrorBoundaryPoc/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorBoundaryPoc';

--- a/packages/carbon-addons-boomerang-react/src/styles/index.scss
+++ b/packages/carbon-addons-boomerang-react/src/styles/index.scss
@@ -72,6 +72,7 @@ $css--plex: true !default;
 @import '../components/DynamicFormik/dynamicFormik';
 @import '../components/ErrorMessage/errorMessage';
 @import '../components/ErrorBoundary/errorBoundary';
+@import '../components/ErrorBoundaryPoc/errorBoundaryPoc';
 @import '../components/ErrorDragon/errorDragon';
 @import '../components/ErrorPage/errorPage';
 @import '../components/FeatureHeader/featureHeader';


### PR DESCRIPTION
Closes #

New ErrorBoundary with react-error-boundary that enables a quick page restore.

#### Changelog

**New**

- ErrorBoundaryPoc


#### Testing / Reviewing

Still need to test in an app.
