### PR TITLE
fix: update Cypress version to work with yarn install

### DIFF
--- a/packages/cra-template-boomerang/template.json
+++ b/packages/cra-template-boomerang/template.json
@@ -23,7 +23,7 @@
       "start": "react-scripts start",
       "test": "react-scripts test --coverage",
       "test:cypress": "start-server-and-test start http://localhost:3000 cypress:ci",
-      "test:staged": "cross-env CI=true react-scripts test --passWithNoTests --findRelatedTests --bail",
+      "test:staged": "cross-env CI=true react-scripts test --passWithNoTests --findRelatedTests --bail"
     },
     "dependencies": {
       "@boomerang-io/carbon-addons-boomerang-react": "0.0.12",
@@ -54,7 +54,7 @@
       "commitizen": "4.0.3",
       "copyfiles": "2.3.0",
       "cross-env": "7.0.2",
-      "cypress": "^5.1.0",
+      "cypress": "^6.4.0",
       "cz-conventional-changelog": "3.1.0",
       "eslint-plugin-cypress": "^2.11.1",
       "eslint-plugin-jest": "^23.11.0",


### PR DESCRIPTION

#### Changelog


**Changed**

 - Updated Cypress versions, because systems sunning with yarn couldn't install some packages on Windows, and that was fixed from the 6.4.0 version 


#### Testing / Reviewing

Create a new project with the boomerang template and install it. 
