### PR TITLE
Fix ibm instrumentation data

### DIFF
--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -218,11 +218,16 @@ function getBluemixSegmentScripts() {
       <script src="${segmentUrl}" crossorigin></script>
       <script>
         window._analytics = {
+          "pageProperties": {
+            "platformTitle": "IBM Consulting Advantage",
+            "productCode": "694970X",
+            "productCodeType": "IBM Consulting Advantage",
+          },
           "commonProperties": {
             "platformTitle": "IBM Consulting Advantage",
             "productCode": "694970X",
-            "productCodeType": "IBM Consulting Advantage",,
-          },
+            "productCodeType": "IBM Consulting Advantage",
+          }
         };
       </script>
       `

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -204,6 +204,8 @@ function getBluemixSegmentScripts() {
           page: {
             pageInfo: {
               pageID: "ibm_consulting_advantage_test",
+              productCode: "694970X",
+              productCodeType: "Consulting Assistants",
               productTitle: "IBM Consulting Advantage",
               analytics: {
                 category: "Offering Interface"

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -218,10 +218,10 @@ function getBluemixSegmentScripts() {
       <script src="${segmentUrl}" crossorigin></script>
       <script>
         window._analytics = {
-          "pageProperties": {
+          "commonProperties": {
             "platformTitle": "IBM Consulting Advantage",
             "productCode": "694970X",
-            "productCodeType": "IBM Consulting Advantage",
+            "productCodeType": "IBM Consulting Advantage",,
           },
         };
       </script>

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.1-beta.0",
+  "version": "1.3.1-beta.1",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.1-beta.1",
+  "version": "1.3.1-beta.2",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.0-beta.11",
+  "version": "1.3.1-beta.0",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.1-beta.2",
+  "version": "1.3.1",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"


### PR DESCRIPTION
Closes #

Using the last version of Carbon React adds some new configuration for IBM Telemetry that triggers Instrumentation Events. Added a configuration for those events so they pass on Segment.

Version: 1.3.1

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
