### PR TITLE
Fix logger health check

### DIFF
--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.0",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.1-beta.2",
+  "version": "1.0.1-beta.3",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.2",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/src/index.js
+++ b/packages/logger-middleware/src/index.js
@@ -9,7 +9,7 @@ const appRoot = require("app-root-path");
  * @param {string} [callingModulePath=""] - path to the module calling
  * @return {object} log4j logger and middleware functions
  */
-module.exports = function (callingModulePath = "") {
+module.exports = function (callingModulePath = "", ) {
   /**
    * Format filename to remove the path to the app.
    * It will isolate the path to the file from the root of the project if
@@ -29,17 +29,29 @@ module.exports = function (callingModulePath = "") {
     categories: {
       default: { appenders: ["default"], level: "all" },
       http: { appenders: ["default"], level: "all" },
+      warn: { appenders: ["default"], level: "warn" },
+      debug: { appenders: ["default"], level: "debug" },
     },
   });
   const logger = log4js.getLogger("app");
   const httpLogger = log4js.getLogger("http");
+  const warnLogger = log4js.getLogger("warn");
+  const debugLogger = log4js.getLogger("debug");
 
   /** Add context so the correct filename is returned when calling either logger*/
   logger.addContext("filename", filename);
   httpLogger.addContext("filename", filename);
+  warnLogger.addContext("filename", filename);
+  debugLogger.addContext("filename", filename);
 
   const middleware = log4js.connectLogger(httpLogger, {
     level: "auto",
   });
-  return { logger, middleware };
+  const warnMiddleware = log4js.connectLogger(warnLogger, {
+    level: "warn",
+  });
+  const debugMiddleware = log4js.connectLogger(debugLogger, {
+    level: "debug",
+  });
+  return { logger, middleware, warnMiddleware, debugMiddleware };
 };

--- a/packages/logger-middleware/src/index.js
+++ b/packages/logger-middleware/src/index.js
@@ -50,7 +50,7 @@ module.exports = function (callingModulePath = "", ) {
   const middleware = log4js.connectLogger(httpLogger, {
     level: "auto",
   });
-  const healthMiddleware = log4js.connectLogger(warnLogger, {
+  const healthMiddleware = log4js.connectLogger(healthLogger, {
     level: "debug",
   });
   return { logger, middleware, healthMiddleware };

--- a/packages/logger-middleware/src/index.js
+++ b/packages/logger-middleware/src/index.js
@@ -51,7 +51,7 @@ module.exports = function (callingModulePath = "", ) {
     level: "auto",
   });
   const healthMiddleware = log4js.connectLogger(warnLogger, {
-    level: "warn",
+    level: "debug",
   });
   return { logger, middleware, healthMiddleware };
 };

--- a/packages/logger-middleware/src/index.js
+++ b/packages/logger-middleware/src/index.js
@@ -16,6 +16,7 @@ module.exports = function (callingModulePath = "", ) {
    * the entire path to file is passed as an argument. Only take last 40 characters and pad if shorter to match log4j format
    */
   const filename = callingModulePath.replace(appRoot, "").slice(-40).padEnd(40, " ");
+  const infoFilename = callingModulePath.replace(appRoot, "").slice(-40).padEnd(40, " ");
   log4js.configure({
     appenders: {
       default: {
@@ -25,33 +26,32 @@ module.exports = function (callingModulePath = "", ) {
           pattern: "[%d{yyyy-MM-dd hh:mm:ss.SSS}] [%p] [%z] [%c] %X{filename} : %m%n",
         },
       },
+      filtered: {
+        type: "noLogFilter",
+        exclude: ["health"],
+        appender: "default",
+      },
     },
     categories: {
       default: { appenders: ["default"], level: "all" },
       http: { appenders: ["default"], level: "all" },
-      warn: { appenders: ["default"], level: "warn" },
-      debug: { appenders: ["default"], level: "debug" },
+      health: { appenders: ["filtered"], level: "info" },
     },
   });
   const logger = log4js.getLogger("app");
   const httpLogger = log4js.getLogger("http");
-  const warnLogger = log4js.getLogger("warn");
-  const debugLogger = log4js.getLogger("debug");
+  const healthLogger = log4js.getLogger("health");
 
   /** Add context so the correct filename is returned when calling either logger*/
   logger.addContext("filename", filename);
   httpLogger.addContext("filename", filename);
-  warnLogger.addContext("filename", filename);
-  debugLogger.addContext("filename", filename);
+  healthLogger.addContext("filename", filename);
 
   const middleware = log4js.connectLogger(httpLogger, {
     level: "auto",
   });
-  const warnMiddleware = log4js.connectLogger(warnLogger, {
+  const healthMiddleware = log4js.connectLogger(warnLogger, {
     level: "warn",
   });
-  const debugMiddleware = log4js.connectLogger(debugLogger, {
-    level: "debug",
-  });
-  return { logger, middleware, warnMiddleware, debugMiddleware };
+  return { logger, middleware, healthMiddleware };
 };

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -82,7 +82,7 @@ function createBoomerangServer({
       switch (status.status) {
         case "STARTING":
         case "UP":          
-          // res.statusCode = 200; break;
+          next();
           break;
         default:        
           res.statusCode = 503;

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -74,9 +74,9 @@ function createBoomerangServer({
   app.use(bodyParser.urlencoded({ extended: true }));
 
   // Initialize healthchecker and add routes
-  // const healthchecker = new health.HealthChecker();
-  // app.use("/health", health.LivenessEndpoint(healthchecker));
-  // app.use("/ready", health.ReadinessEndpoint(healthchecker));
+  const healthchecker = new health.HealthChecker();
+  app.use("/health", health.LivenessEndpoint(healthchecker));
+  app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets
   const appRouter = express.Router();

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -53,7 +53,7 @@ function createBoomerangServer({
   app.use(compression());
 
   // Logging
-  app.use(boomerangLogger.middleware);
+  app.use(boomerangLogger.healthMiddleware);
 
   // Security
   const helmet = require("helmet");

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -33,6 +33,7 @@ function createBoomerangServer({
     HTML_HEAD_INJECTED_SCRIPTS,
     BUILD_DIR = "build",
     CORS_CONFIG,
+    DEBUG_ENABLED = false
   } = process.env;
 
   const appCorsConfig = corsConfig || parseJSONString(CORS_CONFIG);
@@ -53,7 +54,7 @@ function createBoomerangServer({
   app.use(compression());
 
   // Logging
-  app.use(boomerangLogger.healthMiddleware);
+  app.use(DEBUG_ENABLED ? boomerangLogger.debugHealthMiddleware : boomerangLogger.healthMiddleware);
 
   // Security
   const helmet = require("helmet");

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -53,7 +53,7 @@ function createBoomerangServer({
   app.use(compression());
 
   // Logging
-  app.use(boomerangLogger.middleware);
+  app.use(boomerangLogger.warnMiddleware);
 
   // Security
   const helmet = require("helmet");
@@ -75,10 +75,7 @@ function createBoomerangServer({
 
   // Initialize healthchecker and add routes
   const healthchecker = new health.HealthChecker();
-  app.use("/health", health.LivenessEndpoint(healthchecker).then(middleware => {
-    logger.info("Testing");
-    logger.info(middleware);
-  }));
+  app.use("/health", health.LivenessEndpoint(healthchecker));
   app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -4,7 +4,6 @@
 const path = require("path");
 const fs = require("fs");
 const cors = require("cors");
-const http = require("http");
 const serialize = require("serialize-javascript");
 const boomerangLogger = require("@boomerang-io/logger-middleware")("webapp-spa-server/index.js");
 const health = require("@cloudnative/health-connect");
@@ -75,24 +74,9 @@ function createBoomerangServer({
   app.use(bodyParser.urlencoded({ extended: true }));
 
   // Initialize healthchecker and add routes
-  const healthchecker = new health.HealthChecker();
-  // app.use("/health", (req, res, next) => {
-  //   healthchecker.getLivenessStatus().then((status) => {
-  //     logger.debug(status);
-  //     switch (status.status) {
-  //       case "STARTING":
-  //       case "UP":          
-  //         next();
-  //         break;
-  //       default:        
-  //         res.statusCode = 503;
-  //         res.write(JSON.stringify(status));
-  //         break;
-  //     }
-  //     res.end();
-  //   }).catch((err) => {res.end()});
-  // });
-  app.use("/ready", health.ReadinessEndpoint(healthchecker));
+  // const healthchecker = new health.HealthChecker();
+  // app.use("/health", health.LivenessEndpoint(healthchecker));
+  // app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets
   const appRouter = express.Router();

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -75,7 +75,10 @@ function createBoomerangServer({
 
   // Initialize healthchecker and add routes
   const healthchecker = new health.HealthChecker();
-  app.use("/health", health.LivenessEndpoint(healthchecker));
+  app.use("/health", health.LivenessEndpoint(healthchecker).then(middleware => {
+    logger.info("Testing");
+    logger.info(middleware);
+  }));
   app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -4,6 +4,7 @@
 const path = require("path");
 const fs = require("fs");
 const cors = require("cors");
+const http = require("http");
 const serialize = require("serialize-javascript");
 const boomerangLogger = require("@boomerang-io/logger-middleware")("webapp-spa-server/index.js");
 const health = require("@cloudnative/health-connect");
@@ -53,7 +54,7 @@ function createBoomerangServer({
   app.use(compression());
 
   // Logging
-  app.use(boomerangLogger.warnMiddleware);
+  app.use(boomerangLogger.middleware);
 
   // Security
   const helmet = require("helmet");
@@ -75,7 +76,22 @@ function createBoomerangServer({
 
   // Initialize healthchecker and add routes
   const healthchecker = new health.HealthChecker();
-  app.use("/health", health.LivenessEndpoint(healthchecker));
+  app.use("/health", (req, res, next) => {
+    healthchecker.getLivenessStatus().then((status) => {
+      logger.debug(status);
+      switch (status.status) {
+        case "STARTING":
+        case "UP":          
+          // res.statusCode = 200; break;
+          break;
+        default:        
+          res.statusCode = 503;
+          res.write(JSON.stringify(status));
+          break;
+      }
+      res.end();
+    }).catch((err) => {res.end()});
+  });
   app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets

--- a/packages/webapp-spa-server/index.js
+++ b/packages/webapp-spa-server/index.js
@@ -76,22 +76,22 @@ function createBoomerangServer({
 
   // Initialize healthchecker and add routes
   const healthchecker = new health.HealthChecker();
-  app.use("/health", (req, res, next) => {
-    healthchecker.getLivenessStatus().then((status) => {
-      logger.debug(status);
-      switch (status.status) {
-        case "STARTING":
-        case "UP":          
-          next();
-          break;
-        default:        
-          res.statusCode = 503;
-          res.write(JSON.stringify(status));
-          break;
-      }
-      res.end();
-    }).catch((err) => {res.end()});
-  });
+  // app.use("/health", (req, res, next) => {
+  //   healthchecker.getLivenessStatus().then((status) => {
+  //     logger.debug(status);
+  //     switch (status.status) {
+  //       case "STARTING":
+  //       case "UP":          
+  //         next();
+  //         break;
+  //       default:        
+  //         res.statusCode = 503;
+  //         res.write(JSON.stringify(status));
+  //         break;
+  //     }
+  //     res.end();
+  //   }).catch((err) => {res.end()});
+  // });
   app.use("/ready", health.ReadinessEndpoint(healthchecker));
 
   // Create endpoint for the app serve static assets

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.7",
+  "version": "1.3.4-beta.8",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -25,7 +25,7 @@
     "start": "node tester.js"
   },
   "dependencies": {
-    "@boomerang-io/logger-middleware": "1.0.1-beta.3",
+    "@boomerang-io/logger-middleware": "1.0.1-beta.4",
     "@cloudnative/health-connect": "^2.1.0",
     "body-parser": "^1.20.3",
     "compression": "^1.7.4",

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -25,7 +25,7 @@
     "start": "node tester.js"
   },
   "dependencies": {
-    "@boomerang-io/logger-middleware": "1.0.1-beta.0",
+    "@boomerang-io/logger-middleware": "1.0.1-beta.1",
     "@cloudnative/health-connect": "^2.1.0",
     "body-parser": "^1.20.3",
     "compression": "^1.7.4",

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.4",
+  "version": "1.3.4-beta.5",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.6",
+  "version": "1.3.4-beta.7",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"
@@ -25,7 +25,7 @@
     "start": "node tester.js"
   },
   "dependencies": {
-    "@boomerang-io/logger-middleware": "1.0.1-beta.1",
+    "@boomerang-io/logger-middleware": "1.0.1-beta.3",
     "@cloudnative/health-connect": "^2.1.0",
     "body-parser": "^1.20.3",
     "compression": "^1.7.4",

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.2",
+  "version": "1.3.4-beta.3",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.1",
+  "version": "1.3.4-beta.2",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.3",
+  "version": "1.3.4-beta.4",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.0",
+  "version": "1.3.4-beta.1",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"
@@ -25,7 +25,7 @@
     "start": "node tester.js"
   },
   "dependencies": {
-    "@boomerang-io/logger-middleware": "1.0.0",
+    "@boomerang-io/logger-middleware": "1.0.1-beta.0",
     "@cloudnative/health-connect": "^2.1.0",
     "body-parser": "^1.20.3",
     "compression": "^1.7.4",

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.5",
+  "version": "1.3.4-beta.6",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.3",
+  "version": "1.3.4-beta.0",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/webapp-spa-server/pnpm-lock.yaml
+++ b/packages/webapp-spa-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@boomerang-io/logger-middleware':
-        specifier: 1.0.1-beta.1
-        version: 1.0.1-beta.1
+        specifier: 1.0.1-beta.3
+        version: 1.0.1-beta.3
       '@cloudnative/health-connect':
         specifier: ^2.1.0
         version: 2.1.0
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.1':
-    resolution: {integrity: sha512-6BsVA/mO4hnjukircuntQ3O7sGQXhi+8vn2MbfDn6rQqlFVkKS/Sw+Q+wBaSvUCb7yGFV+uMGMTTVVncWsgXVA==}
+  '@boomerang-io/logger-middleware@1.0.1-beta.3':
+    resolution: {integrity: sha512-QviJUFEqz0WCdHjQgQfs9YxG5g0XTJ1jrcJkuHw0gw+jEIbSFvQJpakRyjmcdDdmi0JZnJuBI6IXoEysttgTEw==}
 
   '@cloudnative/health-connect@2.1.0':
     resolution: {integrity: sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==}
@@ -747,7 +747,7 @@ packages:
 
 snapshots:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.1':
+  '@boomerang-io/logger-middleware@1.0.1-beta.3':
     dependencies:
       app-root-path: 3.0.0
       log4js: 6.9.1

--- a/packages/webapp-spa-server/pnpm-lock.yaml
+++ b/packages/webapp-spa-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@boomerang-io/logger-middleware':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.0.1-beta.0
+        version: 1.0.1-beta.0
       '@cloudnative/health-connect':
         specifier: ^2.1.0
         version: 2.1.0
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@boomerang-io/logger-middleware@1.0.0':
-    resolution: {integrity: sha512-CXS40RZMtvq1SAbbbjpAfzj4c+MjaVqyGKFGLFz67tQmLksZvsnIQdS1e7Qz1qFi+MBeqAX8s5za5Q5UNbsHxw==}
+  '@boomerang-io/logger-middleware@1.0.1-beta.0':
+    resolution: {integrity: sha512-qpL1WD2OuFqSSR+xk1mD0EtIa6o97HNmexZ9Wh0QGK3XMY0IJzS7ZqqxSluHy3Rh0N0QY4ERi/mSrJqfMQSPUQ==}
 
   '@cloudnative/health-connect@2.1.0':
     resolution: {integrity: sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==}
@@ -747,7 +747,7 @@ packages:
 
 snapshots:
 
-  '@boomerang-io/logger-middleware@1.0.0':
+  '@boomerang-io/logger-middleware@1.0.1-beta.0':
     dependencies:
       app-root-path: 3.0.0
       log4js: 6.9.1

--- a/packages/webapp-spa-server/pnpm-lock.yaml
+++ b/packages/webapp-spa-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@boomerang-io/logger-middleware':
-        specifier: 1.0.1-beta.3
-        version: 1.0.1-beta.3
+        specifier: 1.0.1-beta.4
+        version: 1.0.1-beta.4
       '@cloudnative/health-connect':
         specifier: ^2.1.0
         version: 2.1.0
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.3':
-    resolution: {integrity: sha512-QviJUFEqz0WCdHjQgQfs9YxG5g0XTJ1jrcJkuHw0gw+jEIbSFvQJpakRyjmcdDdmi0JZnJuBI6IXoEysttgTEw==}
+  '@boomerang-io/logger-middleware@1.0.1-beta.4':
+    resolution: {integrity: sha512-w6yQN7E8gZtvVOGN4M9tuoU6+GZB4e+/5gbp7m+pyR7CN0a3pZCpoQtdZunR70vyM0/5QrqsQTtspsnjz1OLSQ==}
 
   '@cloudnative/health-connect@2.1.0':
     resolution: {integrity: sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==}
@@ -747,7 +747,7 @@ packages:
 
 snapshots:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.3':
+  '@boomerang-io/logger-middleware@1.0.1-beta.4':
     dependencies:
       app-root-path: 3.0.0
       log4js: 6.9.1

--- a/packages/webapp-spa-server/pnpm-lock.yaml
+++ b/packages/webapp-spa-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@boomerang-io/logger-middleware':
-        specifier: 1.0.1-beta.0
-        version: 1.0.1-beta.0
+        specifier: 1.0.1-beta.1
+        version: 1.0.1-beta.1
       '@cloudnative/health-connect':
         specifier: ^2.1.0
         version: 2.1.0
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.0':
-    resolution: {integrity: sha512-qpL1WD2OuFqSSR+xk1mD0EtIa6o97HNmexZ9Wh0QGK3XMY0IJzS7ZqqxSluHy3Rh0N0QY4ERi/mSrJqfMQSPUQ==}
+  '@boomerang-io/logger-middleware@1.0.1-beta.1':
+    resolution: {integrity: sha512-6BsVA/mO4hnjukircuntQ3O7sGQXhi+8vn2MbfDn6rQqlFVkKS/Sw+Q+wBaSvUCb7yGFV+uMGMTTVVncWsgXVA==}
 
   '@cloudnative/health-connect@2.1.0':
     resolution: {integrity: sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==}
@@ -747,7 +747,7 @@ packages:
 
 snapshots:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.0':
+  '@boomerang-io/logger-middleware@1.0.1-beta.1':
     dependencies:
       app-root-path: 3.0.0
       log4js: 6.9.1


### PR DESCRIPTION
Closes #

INFO logs were being sent every 15 seconds, updated boomerang logger with a new middleware to filter INFO types and remove DEBUG, just adding when flag is true.

Version
1.3.4-beta.8

Tested on Catalog  7.17.150

```
[2025-04-03 06:22:18.774] [INFO] [1] [http] webapp-spa-server/index.js               : 10.241.0.30 - - "GET /health HTTP/1.1" 200 - "" "kube-probe/1.30"

[2025-04-03 06:22:33.774] [INFO] [1] [http] webapp-spa-server/index.js               : 10.241.0.30 - - "GET /health HTTP/1.1" 200 - "" "kube-probe/1.30"

[2025-04-03 06:22:48.774] [INFO] [1] [http] webapp-spa-server/index.js               : 10.241.0.30 - - "GET /health HTTP/1.1" 200 - "" "kube-probe/1.30"

[2025-04-03 06:23:03.774] [INFO] [1] [http] webapp-spa-server/index.js               : 10.241.0.30 - - "GET /health HTTP/1.1" 200 - "" "kube-probe/1.30"
```
#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
