### PR TITLE
fix: filter INFO logs

### DIFF
--- a/packages/logger-middleware/package.json
+++ b/packages/logger-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/logger-middleware",
   "description": "Boomerang logging middleware for logging consistently on the Boomerang platform",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/packages/logger-middleware/src/index.js
+++ b/packages/logger-middleware/src/index.js
@@ -34,7 +34,7 @@ module.exports = function (callingModulePath = "", ) {
       },
       filtered: {
         type: "noLogFilter",
-        exclude: ["health"],
+        exclude: [".*"],
         appender: "infoFilter",
       },
       errorFilter: {

--- a/packages/webapp-spa-server/package.json
+++ b/packages/webapp-spa-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/webapp-spa-server",
   "description": "Webapp Server for React-based SPA w/ client-side routing",
-  "version": "1.3.4-beta.8",
+  "version": "1.3.4-beta.9",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"
@@ -25,7 +25,7 @@
     "start": "node tester.js"
   },
   "dependencies": {
-    "@boomerang-io/logger-middleware": "1.0.1-beta.4",
+    "@boomerang-io/logger-middleware": "1.0.1-beta.5",
     "@cloudnative/health-connect": "^2.1.0",
     "body-parser": "^1.20.3",
     "compression": "^1.7.4",

--- a/packages/webapp-spa-server/pnpm-lock.yaml
+++ b/packages/webapp-spa-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@boomerang-io/logger-middleware':
-        specifier: 1.0.1-beta.4
-        version: 1.0.1-beta.4
+        specifier: 1.0.1-beta.5
+        version: 1.0.1-beta.5
       '@cloudnative/health-connect':
         specifier: ^2.1.0
         version: 2.1.0
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.4':
-    resolution: {integrity: sha512-w6yQN7E8gZtvVOGN4M9tuoU6+GZB4e+/5gbp7m+pyR7CN0a3pZCpoQtdZunR70vyM0/5QrqsQTtspsnjz1OLSQ==}
+  '@boomerang-io/logger-middleware@1.0.1-beta.5':
+    resolution: {integrity: sha512-80MG/uVJSuW4c9yn1N8jMx090CqhjONJGJxam5cpUzTZrypsevGYQuNv8xN7SPChGxV8gNKaRu2daaWK/Rim4A==}
 
   '@cloudnative/health-connect@2.1.0':
     resolution: {integrity: sha512-GieeiusY64i1Q5LdAf70n5W08MF5uom3qdVvnwIed/asBqpNPv7hlC6FGSH20lTYvyujF3wV5oBDcTa4SS/cbA==}
@@ -747,7 +747,7 @@ packages:
 
 snapshots:
 
-  '@boomerang-io/logger-middleware@1.0.1-beta.4':
+  '@boomerang-io/logger-middleware@1.0.1-beta.5':
     dependencies:
       app-root-path: 3.0.0
       log4js: 6.9.1


### PR DESCRIPTION
Closes #

The Pods Logs are showing many `[INFO]` logs, example: https://console-openshift-console.apps.ocp2.cloud.boomerangplatform.net/k8s/ns/bmrg-dev/pods/bmrg-core-apps-catalog-775f4597c7-kv8zx/logs

Will make an update to remove them.

#### Changelog

**Changed**

- Update `logger-middleware` infoFilter to exclude all.

#### Testing / Reviewing

- Check Pod logs.
